### PR TITLE
アニメリストのフェッチ方法 (#77)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,17 +1,27 @@
 import 'package:animeishi/ui/auth/view/auth_page.dart';
+import 'package:animeishi/ui/animes/view_model/anime_list_view_model.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'アニ名刺',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
+    return MultiProvider(
+      providers: [
+        // アプリケーション全体でAnimeListViewModelを共有
+        ChangeNotifierProvider(
+          create: (_) => AnimeListViewModel(),
+        ),
+      ],
+      child: MaterialApp(
+        title: 'アニ名刺',
+        theme: ThemeData(
+          primarySwatch: Colors.blue,
+        ),
+        home: AuthPage(),
       ),
-      home: AuthPage(),
     );
   }
 }

--- a/lib/ui/animes/view/anime_list_page.dart
+++ b/lib/ui/animes/view/anime_list_page.dart
@@ -4,9 +4,7 @@ import '../view_model/anime_list_view_model.dart';
 import '../components/anime_card.dart';
 import '../components/anime_list_header.dart';
 import '../components/anime_notification.dart';
-import 'package:animeishi/model/factory/anime_list_factory.dart';
 import 'package:animeishi/ui/home/view/home_page.dart';
-import 'package:animeishi/ui/auth/components/auth_widgets.dart';
 import 'package:animeishi/ui/watch/view/watch_anime.dart';
 
 class AnimeListPage extends StatelessWidget {
@@ -14,13 +12,17 @@ class AnimeListPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) {
-        final viewModel = AnimeListViewModel();
+    // アプリケーション全体で共有されているViewModelを使用
+    final viewModel = Provider.of<AnimeListViewModel>(context, listen: false);
+
+    // 初回のみフェッチ
+    if (!viewModel.isLoading && viewModel.animeList.isEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
         viewModel.fetchFromServer();
-        return viewModel;
-      },
-      child: Scaffold(
+      });
+    }
+
+    return Scaffold(
         backgroundColor: Colors.transparent,
         body: Container(
           decoration: BoxDecoration(
@@ -397,7 +399,8 @@ class AnimeListPage extends StatelessWidget {
   Future<void> _handleFetchFromServer(
       BuildContext context, AnimeListViewModel viewModel) async {
     try {
-      await viewModel.fetchFromServer();
+      // force: true で強制的に再フェッチ
+      await viewModel.fetchFromServer(force: true);
       final count = viewModel.animeList.length;
       AnimeNotification.showSuccess(
         context,

--- a/lib/ui/animes/view/anime_list_page.dart
+++ b/lib/ui/animes/view/anime_list_page.dart
@@ -23,8 +23,8 @@ class AnimeListPage extends StatelessWidget {
     }
 
     return Scaffold(
-        backgroundColor: Colors.transparent,
-        body: Container(
+      backgroundColor: Colors.transparent,
+      body: Container(
           decoration: BoxDecoration(
             gradient: LinearGradient(
               begin: Alignment.topLeft,
@@ -227,7 +227,7 @@ class AnimeListPage extends StatelessWidget {
             },
           ),
         ),
-        floatingActionButton: Consumer<AnimeListViewModel>(
+      floatingActionButton: Consumer<AnimeListViewModel>(
           builder: (context, viewModel, child) {
             final hasSelected = viewModel.selectedAnime.isNotEmpty;
 

--- a/lib/ui/animes/view/anime_list_page.dart
+++ b/lib/ui/animes/view/anime_list_page.dart
@@ -25,251 +25,249 @@ class AnimeListPage extends StatelessWidget {
     return Scaffold(
       backgroundColor: Colors.transparent,
       body: Container(
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-              colors: [
-                Color(0xFFD6BCFA), // ソフトパープル
-                Color(0xFFBFDBFE), // ソフトブルー
-                Color(0xFFFBCFE8), // ソフトピンク
-                Color(0xFFD1FAE5), // ソフトグリーン
-              ],
-            ),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [
+              Color(0xFFD6BCFA), // ソフトパープル
+              Color(0xFFBFDBFE), // ソフトブルー
+              Color(0xFFFBCFE8), // ソフトピンク
+              Color(0xFFD1FAE5), // ソフトグリーン
+            ],
           ),
-          child: Consumer<AnimeListViewModel>(
-            builder: (context, viewModel, child) {
-              return CustomScrollView(
-                physics: BouncingScrollPhysics(),
-                slivers: [
-                  // カスタムAppBar
-                  SliverAppBar(
-                    expandedHeight: 120,
-                    floating: false,
-                    pinned: true,
-                    backgroundColor: Colors.transparent,
-                    elevation: 0,
-                    leading: Container(
-                      margin: EdgeInsets.all(8),
-                      decoration: BoxDecoration(
-                        color: Colors.white.withOpacity(0.9),
+        ),
+        child: Consumer<AnimeListViewModel>(
+          builder: (context, viewModel, child) {
+            return CustomScrollView(
+              physics: BouncingScrollPhysics(),
+              slivers: [
+                // カスタムAppBar
+                SliverAppBar(
+                  expandedHeight: 120,
+                  floating: false,
+                  pinned: true,
+                  backgroundColor: Colors.transparent,
+                  elevation: 0,
+                  leading: Container(
+                    margin: EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.9),
+                      borderRadius: BorderRadius.circular(12),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.1),
+                          blurRadius: 8,
+                          offset: Offset(0, 2),
+                        ),
+                      ],
+                    ),
+                    child: Material(
+                      color: Colors.transparent,
+                      child: InkWell(
                         borderRadius: BorderRadius.circular(12),
+                        onTap: () {
+                          Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(builder: (context) => HomePage()),
+                          );
+                        },
+                        child: Icon(
+                          Icons.arrow_back_ios_new,
+                          color: Color(0xFF667eea),
+                          size: 20,
+                        ),
+                      ),
+                    ),
+                  ),
+                  flexibleSpace: FlexibleSpaceBar(
+                    centerTitle: true,
+                    title: Container(
+                      padding:
+                          EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          colors: [
+                            Colors.white.withOpacity(0.9),
+                            Colors.white.withOpacity(0.7),
+                          ],
+                        ),
+                        borderRadius: BorderRadius.circular(20),
                         boxShadow: [
                           BoxShadow(
                             color: Colors.black.withOpacity(0.1),
-                            blurRadius: 8,
+                            blurRadius: 10,
                             offset: Offset(0, 2),
                           ),
                         ],
                       ),
-                      child: Material(
-                        color: Colors.transparent,
-                        child: InkWell(
-                          borderRadius: BorderRadius.circular(12),
-                          onTap: () {
-                            Navigator.pushReplacement(
-                              context,
-                              MaterialPageRoute(
-                                  builder: (context) => HomePage()),
-                            );
-                          },
-                          child: Icon(
-                            Icons.arrow_back_ios_new,
-                            color: Color(0xFF667eea),
-                            size: 20,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Container(
+                            padding: EdgeInsets.all(6),
+                            decoration: BoxDecoration(
+                              gradient: LinearGradient(
+                                colors: [
+                                  Color(0xFF667eea),
+                                  Color(0xFF764ba2),
+                                ],
+                              ),
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                            child: Icon(
+                              Icons.movie_outlined,
+                              color: Colors.white,
+                              size: 16,
+                            ),
                           ),
-                        ),
-                      ),
-                    ),
-                    flexibleSpace: FlexibleSpaceBar(
-                      centerTitle: true,
-                      title: Container(
-                        padding:
-                            EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                        decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            colors: [
-                              Colors.white.withOpacity(0.9),
-                              Colors.white.withOpacity(0.7),
-                            ],
+                          SizedBox(width: 8),
+                          Text(
+                            'アニメリスト',
+                            style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w700,
+                              color: Color(0xFF2D3748),
+                            ),
                           ),
-                          borderRadius: BorderRadius.circular(20),
-                          boxShadow: [
-                            BoxShadow(
-                              color: Colors.black.withOpacity(0.1),
-                              blurRadius: 10,
-                              offset: Offset(0, 2),
-                            ),
-                          ],
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Container(
-                              padding: EdgeInsets.all(6),
-                              decoration: BoxDecoration(
-                                gradient: LinearGradient(
-                                  colors: [
-                                    Color(0xFF667eea),
-                                    Color(0xFF764ba2),
-                                  ],
-                                ),
-                                borderRadius: BorderRadius.circular(10),
-                              ),
-                              child: Icon(
-                                Icons.movie_outlined,
-                                color: Colors.white,
-                                size: 16,
-                              ),
-                            ),
-                            SizedBox(width: 8),
-                            Text(
-                              'アニメリスト',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.w700,
-                                color: Color(0xFF2D3748),
-                              ),
-                            ),
-                          ],
-                        ),
+                        ],
                       ),
                     ),
                   ),
+                ),
 
-                  // ヘッダー部分
-                  SliverToBoxAdapter(
-                    child: AnimeListHeader(
-                      viewModel: viewModel,
-                      onFetchFromServer: () =>
-                          _handleFetchFromServer(context, viewModel),
-                    ),
+                // ヘッダー部分
+                SliverToBoxAdapter(
+                  child: AnimeListHeader(
+                    viewModel: viewModel,
+                    onFetchFromServer: () =>
+                        _handleFetchFromServer(context, viewModel),
                   ),
+                ),
 
-                  // アニメリスト
-                  SliverPadding(
-                    padding: EdgeInsets.only(top: 20, bottom: 20),
-                    sliver: viewModel.animeList.isEmpty
-                        ? SliverToBoxAdapter(
-                            child: _buildEmptyState(),
-                          )
-                        : SliverList(
-                            delegate: SliverChildBuilderDelegate(
-                              (context, index) {
-                                final anime = viewModel.animeList[index];
-                                final tid = anime['tid'] ?? 'N/A';
-                                final isSelected =
-                                    viewModel.selectedAnime.contains(tid);
-                                final isRegistered =
-                                    viewModel.registeredAnime.contains(tid);
+                // アニメリスト
+                SliverPadding(
+                  padding: EdgeInsets.only(top: 20, bottom: 20),
+                  sliver: viewModel.animeList.isEmpty
+                      ? SliverToBoxAdapter(
+                          child: _buildEmptyState(),
+                        )
+                      : SliverList(
+                          delegate: SliverChildBuilderDelegate(
+                            (context, index) {
+                              final anime = viewModel.animeList[index];
+                              final tid = anime['tid'] ?? 'N/A';
+                              final isSelected =
+                                  viewModel.selectedAnime.contains(tid);
+                              final isRegistered =
+                                  viewModel.registeredAnime.contains(tid);
 
-                                // 登録済みアニメの場合はスワイプで削除可能にする
-                                if (isRegistered) {
-                                  return Dismissible(
-                                    key: Key('anime_$tid'),
-                                    direction: DismissDirection.endToStart,
-                                    background: Container(
-                                      margin: EdgeInsets.symmetric(
-                                          horizontal: 16, vertical: 8),
-                                      decoration: BoxDecoration(
-                                        gradient: LinearGradient(
-                                          colors: [
-                                            Colors.red[400]!,
-                                            Colors.red[600]!,
-                                          ],
-                                        ),
-                                        borderRadius: BorderRadius.circular(20),
-                                      ),
-                                      alignment: Alignment.centerRight,
-                                      padding: EdgeInsets.only(right: 30),
-                                      child: Column(
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.center,
-                                        children: [
-                                          Icon(
-                                            Icons.delete_outline,
-                                            color: Colors.white,
-                                            size: 32,
-                                          ),
-                                          SizedBox(height: 4),
-                                          Text(
-                                            '削除',
-                                            style: TextStyle(
-                                              color: Colors.white,
-                                              fontSize: 12,
-                                              fontWeight: FontWeight.bold,
-                                            ),
-                                          ),
+                              // 登録済みアニメの場合はスワイプで削除可能にする
+                              if (isRegistered) {
+                                return Dismissible(
+                                  key: Key('anime_$tid'),
+                                  direction: DismissDirection.endToStart,
+                                  background: Container(
+                                    margin: EdgeInsets.symmetric(
+                                        horizontal: 16, vertical: 8),
+                                    decoration: BoxDecoration(
+                                      gradient: LinearGradient(
+                                        colors: [
+                                          Colors.red[400]!,
+                                          Colors.red[600]!,
                                         ],
                                       ),
+                                      borderRadius: BorderRadius.circular(20),
                                     ),
-                                    confirmDismiss: (direction) async {
-                                      return await _showUnregisterDialog(
-                                          context,
-                                          viewModel,
-                                          tid,
-                                          anime['title'] ?? 'タイトル不明');
-                                    },
-                                    child: _buildAnimeCard(context, anime,
-                                        isSelected, isRegistered, viewModel),
-                                  );
-                                } else {
-                                  return _buildAnimeCard(context, anime,
-                                      isSelected, isRegistered, viewModel);
-                                }
-                              },
-                              childCount: viewModel.animeList.length,
-                            ),
+                                    alignment: Alignment.centerRight,
+                                    padding: EdgeInsets.only(right: 30),
+                                    child: Column(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.center,
+                                      children: [
+                                        Icon(
+                                          Icons.delete_outline,
+                                          color: Colors.white,
+                                          size: 32,
+                                        ),
+                                        SizedBox(height: 4),
+                                        Text(
+                                          '削除',
+                                          style: TextStyle(
+                                            color: Colors.white,
+                                            fontSize: 12,
+                                            fontWeight: FontWeight.bold,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                  confirmDismiss: (direction) async {
+                                    return await _showUnregisterDialog(
+                                        context,
+                                        viewModel,
+                                        tid,
+                                        anime['title'] ?? 'タイトル不明');
+                                  },
+                                  child: _buildAnimeCard(context, anime,
+                                      isSelected, isRegistered, viewModel),
+                                );
+                              } else {
+                                return _buildAnimeCard(context, anime,
+                                    isSelected, isRegistered, viewModel);
+                              }
+                            },
+                            childCount: viewModel.animeList.length,
                           ),
-                  ),
-                ],
-              );
-            },
-          ),
-        ),
-      floatingActionButton: Consumer<AnimeListViewModel>(
-          builder: (context, viewModel, child) {
-            final hasSelected = viewModel.selectedAnime.isNotEmpty;
-
-            if (!hasSelected) {
-              return const SizedBox.shrink(); // 選択されたアニメがない場合は非表示
-            }
-
-            return Container(
-              decoration: BoxDecoration(
-                gradient: const LinearGradient(
-                  colors: [Color(0xFF667eea), Color(0xFF764ba2)],
+                        ),
                 ),
-                borderRadius: BorderRadius.circular(16),
-                boxShadow: [
-                  BoxShadow(
-                    color: const Color(0xFF667eea).withOpacity(0.3),
-                    blurRadius: 12,
-                    offset: const Offset(0, 4),
-                  ),
-                ],
-              ),
-              child: FloatingActionButton.extended(
-                onPressed: () => _handleSaveSelected(context, viewModel),
-                backgroundColor: Colors.transparent,
-                elevation: 0,
-                label: Text(
-                  '登録 (${viewModel.selectedAnime.length}件)',
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                    color: Colors.white,
-                  ),
-                ),
-                icon: const Icon(
-                  Icons.bookmark_add,
-                  color: Colors.white,
-                  size: 20,
-                ),
-              ),
+              ],
             );
           },
         ),
+      ),
+      floatingActionButton: Consumer<AnimeListViewModel>(
+        builder: (context, viewModel, child) {
+          final hasSelected = viewModel.selectedAnime.isNotEmpty;
+
+          if (!hasSelected) {
+            return const SizedBox.shrink(); // 選択されたアニメがない場合は非表示
+          }
+
+          return Container(
+            decoration: BoxDecoration(
+              gradient: const LinearGradient(
+                colors: [Color(0xFF667eea), Color(0xFF764ba2)],
+              ),
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: [
+                BoxShadow(
+                  color: const Color(0xFF667eea).withOpacity(0.3),
+                  blurRadius: 12,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: FloatingActionButton.extended(
+              onPressed: () => _handleSaveSelected(context, viewModel),
+              backgroundColor: Colors.transparent,
+              elevation: 0,
+              label: Text(
+                '登録 (${viewModel.selectedAnime.length}件)',
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.white,
+                ),
+              ),
+              icon: const Icon(
+                Icons.bookmark_add,
+                color: Colors.white,
+                size: 20,
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/ui/animes/view_model/anime_list_view_model.dart
+++ b/lib/ui/animes/view_model/anime_list_view_model.dart
@@ -28,7 +28,8 @@ class AnimeListViewModel extends ChangeNotifier {
   SortOrder get sortOrder => _sortOrder; //ソート順を取得するゲッター
   bool get isAscending => _isAscending; //昇順 or 降順を取得
   String get searchQuery => _searchQuery; // 検索クエリを取得するゲッター
-  bool get hasFetchedFromServer => _hasFetchedFromServer; // サーバーから取得済みかどうかを取得するゲッター
+  bool get hasFetchedFromServer =>
+      _hasFetchedFromServer; // サーバーから取得済みかどうかを取得するゲッター
 
   //ソート順の変更
   void setSortOrder(SortOrder order) {


### PR DESCRIPTION
GitHub issue #77: 初回のみフェッチするようにする
現在はアニメ一覧を取得しようとして10000件くらいのfirestoreの情報を毎回とってしまうのでDBにすごいダメージが出てしまう

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized anime list state into an application-wide provider, removing local view-model instantiation and simplifying lifecycle.
  * View now binds to the shared state and triggers a one-time fetch on first display to avoid redundant loads.

* **New Features**
  * Added a fetch-control flag and a public indicator to allow forced refreshes and to track whether an initial server fetch has occurred.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->