### PR TITLE
アニメリストのフェッチ方法 (#77) 

### DIFF
--- a/lib/ui/animes/view/anime_list_page.dart
+++ b/lib/ui/animes/view/anime_list_page.dart
@@ -17,7 +17,7 @@ class AnimeListPage extends StatelessWidget {
     return ChangeNotifierProvider(
       create: (_) {
         final viewModel = AnimeListViewModel();
-        viewModel.fetchFromServer();
+        viewModel.initAnimeList();
         return viewModel;
       },
       child: Scaffold(
@@ -397,7 +397,7 @@ class AnimeListPage extends StatelessWidget {
   Future<void> _handleFetchFromServer(
       BuildContext context, AnimeListViewModel viewModel) async {
     try {
-      await viewModel.fetchFromServer();
+      await viewModel.fetchFromServer(forceRefresh: true);
       final count = viewModel.animeList.length;
       AnimeNotification.showSuccess(
         context,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -749,6 +749,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: bd14436108211b0d4ee5038689a56d4ae3620fd72fd6036e113bf1345bc74d9e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.13"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -940,4 +996,4 @@ packages:
     version: "6.5.0"
 sdks:
   dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   flutter_dotenv: ^5.2.1
   image_gallery_saver: ^2.0.3
   permission_handler: ^12.0.1
+  shared_preferences: ^2.3.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
GitHub issue #77: 初回のみフェッチするようにする
現在はアニメ一覧を取得しようとして10000件くらいのfirestoreの情報を毎回とってしまうのでDBにすごいダメージが出てしまう

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent tracking of downloaded anime lists, enabling offline access on subsequent app launches.
  * Introduced explicit force-refresh capability for server data fetches.
  * Improved anime list initialization process.

* **Chores**
  * Added shared_preferences library to support offline data persistence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->