### PR TITLE
refactor: アニメリストキャッシュをSharedPreferencesで永続化 (#77改善)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,27 +1,17 @@
 import 'package:animeishi/ui/auth/view/auth_page.dart';
-import 'package:animeishi/ui/animes/view_model/anime_list_view_model.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MultiProvider(
-      providers: [
-        // アプリケーション全体でAnimeListViewModelを共有
-        ChangeNotifierProvider(
-          create: (_) => AnimeListViewModel(),
-        ),
-      ],
-      child: MaterialApp(
-        title: 'アニ名刺',
-        theme: ThemeData(
-          primarySwatch: Colors.blue,
-        ),
-        home: AuthPage(),
+    return MaterialApp(
+      title: 'アニ名刺',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
       ),
+      home: AuthPage(),
     );
   }
 }

--- a/lib/ui/animes/view/anime_list_page.dart
+++ b/lib/ui/animes/view/anime_list_page.dart
@@ -4,7 +4,9 @@ import '../view_model/anime_list_view_model.dart';
 import '../components/anime_card.dart';
 import '../components/anime_list_header.dart';
 import '../components/anime_notification.dart';
+import 'package:animeishi/model/factory/anime_list_factory.dart';
 import 'package:animeishi/ui/home/view/home_page.dart';
+import 'package:animeishi/ui/auth/components/auth_widgets.dart';
 import 'package:animeishi/ui/watch/view/watch_anime.dart';
 
 class AnimeListPage extends StatelessWidget {
@@ -12,262 +14,260 @@ class AnimeListPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // アプリケーション全体で共有されているViewModelを使用
-    final viewModel = Provider.of<AnimeListViewModel>(context, listen: false);
-
-    // 初回のみフェッチ
-    if (!viewModel.isLoading && viewModel.animeList.isEmpty) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        viewModel.fetchFromServer();
-      });
-    }
-
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      body: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color(0xFFD6BCFA), // ソフトパープル
-              Color(0xFFBFDBFE), // ソフトブルー
-              Color(0xFFFBCFE8), // ソフトピンク
-              Color(0xFFD1FAE5), // ソフトグリーン
-            ],
+    return ChangeNotifierProvider(
+      create: (_) {
+        final viewModel = AnimeListViewModel();
+        viewModel.initAnimeList();
+        return viewModel;
+      },
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        body: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                Color(0xFFD6BCFA), // ソフトパープル
+                Color(0xFFBFDBFE), // ソフトブルー
+                Color(0xFFFBCFE8), // ソフトピンク
+                Color(0xFFD1FAE5), // ソフトグリーン
+              ],
+            ),
           ),
-        ),
-        child: Consumer<AnimeListViewModel>(
-          builder: (context, viewModel, child) {
-            return CustomScrollView(
-              physics: BouncingScrollPhysics(),
-              slivers: [
-                // カスタムAppBar
-                SliverAppBar(
-                  expandedHeight: 120,
-                  floating: false,
-                  pinned: true,
-                  backgroundColor: Colors.transparent,
-                  elevation: 0,
-                  leading: Container(
-                    margin: EdgeInsets.all(8),
-                    decoration: BoxDecoration(
-                      color: Colors.white.withOpacity(0.9),
-                      borderRadius: BorderRadius.circular(12),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withOpacity(0.1),
-                          blurRadius: 8,
-                          offset: Offset(0, 2),
-                        ),
-                      ],
-                    ),
-                    child: Material(
-                      color: Colors.transparent,
-                      child: InkWell(
-                        borderRadius: BorderRadius.circular(12),
-                        onTap: () {
-                          Navigator.pushReplacement(
-                            context,
-                            MaterialPageRoute(builder: (context) => HomePage()),
-                          );
-                        },
-                        child: Icon(
-                          Icons.arrow_back_ios_new,
-                          color: Color(0xFF667eea),
-                          size: 20,
-                        ),
-                      ),
-                    ),
-                  ),
-                  flexibleSpace: FlexibleSpaceBar(
-                    centerTitle: true,
-                    title: Container(
-                      padding:
-                          EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Consumer<AnimeListViewModel>(
+            builder: (context, viewModel, child) {
+              return CustomScrollView(
+                physics: BouncingScrollPhysics(),
+                slivers: [
+                  // カスタムAppBar
+                  SliverAppBar(
+                    expandedHeight: 120,
+                    floating: false,
+                    pinned: true,
+                    backgroundColor: Colors.transparent,
+                    elevation: 0,
+                    leading: Container(
+                      margin: EdgeInsets.all(8),
                       decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          colors: [
-                            Colors.white.withOpacity(0.9),
-                            Colors.white.withOpacity(0.7),
-                          ],
-                        ),
-                        borderRadius: BorderRadius.circular(20),
+                        color: Colors.white.withOpacity(0.9),
+                        borderRadius: BorderRadius.circular(12),
                         boxShadow: [
                           BoxShadow(
                             color: Colors.black.withOpacity(0.1),
-                            blurRadius: 10,
+                            blurRadius: 8,
                             offset: Offset(0, 2),
                           ),
                         ],
                       ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Container(
-                            padding: EdgeInsets.all(6),
-                            decoration: BoxDecoration(
-                              gradient: LinearGradient(
-                                colors: [
-                                  Color(0xFF667eea),
-                                  Color(0xFF764ba2),
-                                ],
+                      child: Material(
+                        color: Colors.transparent,
+                        child: InkWell(
+                          borderRadius: BorderRadius.circular(12),
+                          onTap: () {
+                            Navigator.pushReplacement(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (context) => HomePage()),
+                            );
+                          },
+                          child: Icon(
+                            Icons.arrow_back_ios_new,
+                            color: Color(0xFF667eea),
+                            size: 20,
+                          ),
+                        ),
+                      ),
+                    ),
+                    flexibleSpace: FlexibleSpaceBar(
+                      centerTitle: true,
+                      title: Container(
+                        padding:
+                            EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            colors: [
+                              Colors.white.withOpacity(0.9),
+                              Colors.white.withOpacity(0.7),
+                            ],
+                          ),
+                          borderRadius: BorderRadius.circular(20),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black.withOpacity(0.1),
+                              blurRadius: 10,
+                              offset: Offset(0, 2),
+                            ),
+                          ],
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Container(
+                              padding: EdgeInsets.all(6),
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  colors: [
+                                    Color(0xFF667eea),
+                                    Color(0xFF764ba2),
+                                  ],
+                                ),
+                                borderRadius: BorderRadius.circular(10),
                               ),
-                              borderRadius: BorderRadius.circular(10),
+                              child: Icon(
+                                Icons.movie_outlined,
+                                color: Colors.white,
+                                size: 16,
+                              ),
                             ),
-                            child: Icon(
-                              Icons.movie_outlined,
-                              color: Colors.white,
-                              size: 16,
+                            SizedBox(width: 8),
+                            Text(
+                              'アニメリスト',
+                              style: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.w700,
+                                color: Color(0xFF2D3748),
+                              ),
                             ),
-                          ),
-                          SizedBox(width: 8),
-                          Text(
-                            'アニメリスト',
-                            style: TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.w700,
-                              color: Color(0xFF2D3748),
-                            ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
                   ),
-                ),
 
-                // ヘッダー部分
-                SliverToBoxAdapter(
-                  child: AnimeListHeader(
-                    viewModel: viewModel,
-                    onFetchFromServer: () =>
-                        _handleFetchFromServer(context, viewModel),
+                  // ヘッダー部分
+                  SliverToBoxAdapter(
+                    child: AnimeListHeader(
+                      viewModel: viewModel,
+                      onFetchFromServer: () =>
+                          _handleFetchFromServer(context, viewModel),
+                    ),
                   ),
-                ),
 
-                // アニメリスト
-                SliverPadding(
-                  padding: EdgeInsets.only(top: 20, bottom: 20),
-                  sliver: viewModel.animeList.isEmpty
-                      ? SliverToBoxAdapter(
-                          child: _buildEmptyState(),
-                        )
-                      : SliverList(
-                          delegate: SliverChildBuilderDelegate(
-                            (context, index) {
-                              final anime = viewModel.animeList[index];
-                              final tid = anime['tid'] ?? 'N/A';
-                              final isSelected =
-                                  viewModel.selectedAnime.contains(tid);
-                              final isRegistered =
-                                  viewModel.registeredAnime.contains(tid);
+                  // アニメリスト
+                  SliverPadding(
+                    padding: EdgeInsets.only(top: 20, bottom: 20),
+                    sliver: viewModel.animeList.isEmpty
+                        ? SliverToBoxAdapter(
+                            child: _buildEmptyState(),
+                          )
+                        : SliverList(
+                            delegate: SliverChildBuilderDelegate(
+                              (context, index) {
+                                final anime = viewModel.animeList[index];
+                                final tid = anime['tid'] ?? 'N/A';
+                                final isSelected =
+                                    viewModel.selectedAnime.contains(tid);
+                                final isRegistered =
+                                    viewModel.registeredAnime.contains(tid);
 
-                              // 登録済みアニメの場合はスワイプで削除可能にする
-                              if (isRegistered) {
-                                return Dismissible(
-                                  key: Key('anime_$tid'),
-                                  direction: DismissDirection.endToStart,
-                                  background: Container(
-                                    margin: EdgeInsets.symmetric(
-                                        horizontal: 16, vertical: 8),
-                                    decoration: BoxDecoration(
-                                      gradient: LinearGradient(
-                                        colors: [
-                                          Colors.red[400]!,
-                                          Colors.red[600]!,
+                                // 登録済みアニメの場合はスワイプで削除可能にする
+                                if (isRegistered) {
+                                  return Dismissible(
+                                    key: Key('anime_$tid'),
+                                    direction: DismissDirection.endToStart,
+                                    background: Container(
+                                      margin: EdgeInsets.symmetric(
+                                          horizontal: 16, vertical: 8),
+                                      decoration: BoxDecoration(
+                                        gradient: LinearGradient(
+                                          colors: [
+                                            Colors.red[400]!,
+                                            Colors.red[600]!,
+                                          ],
+                                        ),
+                                        borderRadius: BorderRadius.circular(20),
+                                      ),
+                                      alignment: Alignment.centerRight,
+                                      padding: EdgeInsets.only(right: 30),
+                                      child: Column(
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.center,
+                                        children: [
+                                          Icon(
+                                            Icons.delete_outline,
+                                            color: Colors.white,
+                                            size: 32,
+                                          ),
+                                          SizedBox(height: 4),
+                                          Text(
+                                            '削除',
+                                            style: TextStyle(
+                                              color: Colors.white,
+                                              fontSize: 12,
+                                              fontWeight: FontWeight.bold,
+                                            ),
+                                          ),
                                         ],
                                       ),
-                                      borderRadius: BorderRadius.circular(20),
                                     ),
-                                    alignment: Alignment.centerRight,
-                                    padding: EdgeInsets.only(right: 30),
-                                    child: Column(
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.center,
-                                      children: [
-                                        Icon(
-                                          Icons.delete_outline,
-                                          color: Colors.white,
-                                          size: 32,
-                                        ),
-                                        SizedBox(height: 4),
-                                        Text(
-                                          '削除',
-                                          style: TextStyle(
-                                            color: Colors.white,
-                                            fontSize: 12,
-                                            fontWeight: FontWeight.bold,
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                  confirmDismiss: (direction) async {
-                                    return await _showUnregisterDialog(
-                                        context,
-                                        viewModel,
-                                        tid,
-                                        anime['title'] ?? 'タイトル不明');
-                                  },
-                                  child: _buildAnimeCard(context, anime,
-                                      isSelected, isRegistered, viewModel),
-                                );
-                              } else {
-                                return _buildAnimeCard(context, anime,
-                                    isSelected, isRegistered, viewModel);
-                              }
-                            },
-                            childCount: viewModel.animeList.length,
+                                    confirmDismiss: (direction) async {
+                                      return await _showUnregisterDialog(
+                                          context,
+                                          viewModel,
+                                          tid,
+                                          anime['title'] ?? 'タイトル不明');
+                                    },
+                                    child: _buildAnimeCard(context, anime,
+                                        isSelected, isRegistered, viewModel),
+                                  );
+                                } else {
+                                  return _buildAnimeCard(context, anime,
+                                      isSelected, isRegistered, viewModel);
+                                }
+                              },
+                              childCount: viewModel.animeList.length,
+                            ),
                           ),
-                        ),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+        floatingActionButton: Consumer<AnimeListViewModel>(
+          builder: (context, viewModel, child) {
+            final hasSelected = viewModel.selectedAnime.isNotEmpty;
+
+            if (!hasSelected) {
+              return const SizedBox.shrink(); // 選択されたアニメがない場合は非表示
+            }
+
+            return Container(
+              decoration: BoxDecoration(
+                gradient: const LinearGradient(
+                  colors: [Color(0xFF667eea), Color(0xFF764ba2)],
                 ),
-              ],
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: [
+                  BoxShadow(
+                    color: const Color(0xFF667eea).withOpacity(0.3),
+                    blurRadius: 12,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: FloatingActionButton.extended(
+                onPressed: () => _handleSaveSelected(context, viewModel),
+                backgroundColor: Colors.transparent,
+                elevation: 0,
+                label: Text(
+                  '登録 (${viewModel.selectedAnime.length}件)',
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                  ),
+                ),
+                icon: const Icon(
+                  Icons.bookmark_add,
+                  color: Colors.white,
+                  size: 20,
+                ),
+              ),
             );
           },
         ),
-      ),
-      floatingActionButton: Consumer<AnimeListViewModel>(
-        builder: (context, viewModel, child) {
-          final hasSelected = viewModel.selectedAnime.isNotEmpty;
-
-          if (!hasSelected) {
-            return const SizedBox.shrink(); // 選択されたアニメがない場合は非表示
-          }
-
-          return Container(
-            decoration: BoxDecoration(
-              gradient: const LinearGradient(
-                colors: [Color(0xFF667eea), Color(0xFF764ba2)],
-              ),
-              borderRadius: BorderRadius.circular(16),
-              boxShadow: [
-                BoxShadow(
-                  color: const Color(0xFF667eea).withOpacity(0.3),
-                  blurRadius: 12,
-                  offset: const Offset(0, 4),
-                ),
-              ],
-            ),
-            child: FloatingActionButton.extended(
-              onPressed: () => _handleSaveSelected(context, viewModel),
-              backgroundColor: Colors.transparent,
-              elevation: 0,
-              label: Text(
-                '登録 (${viewModel.selectedAnime.length}件)',
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: Colors.white,
-                ),
-              ),
-              icon: const Icon(
-                Icons.bookmark_add,
-                color: Colors.white,
-                size: 20,
-              ),
-            ),
-          );
-        },
       ),
     );
   }
@@ -397,8 +397,7 @@ class AnimeListPage extends StatelessWidget {
   Future<void> _handleFetchFromServer(
       BuildContext context, AnimeListViewModel viewModel) async {
     try {
-      // force: true で強制的に再フェッチ
-      await viewModel.fetchFromServer(force: true);
+      await viewModel.fetchFromServer(forceRefresh: true);
       final count = viewModel.animeList.length;
       AnimeNotification.showSuccess(
         context,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -749,6 +749,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: bd14436108211b0d4ee5038689a56d4ae3620fd72fd6036e113bf1345bc74d9e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.13"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -940,4 +996,4 @@ packages:
     version: "6.5.0"
 sdks:
   dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   flutter_dotenv: ^5.2.1
   image_gallery_saver: ^2.0.3
   permission_handler: ^12.0.1
+  shared_preferences: ^2.3.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要
既存の実装 (#164) を改善し、アプリ終了後も初回ダウンロードフラグを永続化することで、真に「初回のみ」サーバーから取得するようにしました。

## 動機
#164 で実装されたメモリベースのキャッシュは以下の問題がありました:
- アプリを再起動するとフラグがリセットされ、毎回約10,000件のFirestoreドキュメントを読み取る
- アプリのライフサイクル全体での最適化になっていない
- 長期的なDB負荷削減効果が限定的

## 変更内容

### 1. SharedPreferencesで永続化
```dart
/// アニメリストが初回ダウンロード済みかどうかを確認
Future<bool> _hasDownloadedAnimeList() async {
  final prefs = await SharedPreferences.getInstance();
  return prefs.getBool(_hasDownloadedKey) ?? false;
}

/// アニメリストをダウンロード済みとしてマーク
Future<void> _markAsDownloaded() async {
  final prefs = await SharedPreferences.getInstance();
  await prefs.setBool(_hasDownloadedKey, true);
}
```

### 2. initAnimeList()メソッドの追加
- 初回ダウンロード済みかチェック
- 未ダウンロード: サーバーから取得してフラグを保存
- ダウンロード済み: Firestoreキャッシュから読み込み

### 3. app.dartの簡素化
- MultiProviderによるグローバル共有を削除
- 各ページで独立したViewModelインスタンスを作成
- SharedPreferencesによる永続化で状態を共有

### 4. forceRefreshパラメータ
- 手動更新時は`forceRefresh: true`で強制的にサーバーから取得

## 実装の比較

### 既存実装 (#164)
- メモリ上のフラグ`_hasFetchedFromServer`
- アプリ起動中のみ有効
- アプリ再起動で毎回ダウンロード

### 今回の実装
- SharedPreferencesで永続化
- アプリ再起動後も有効
- 真に初回のみダウンロード

## 効果
✅ **真の初回のみ取得**: アプリ再起動しても2回目以降はキャッシュを使用  
✅ **長期的なDB負荷削減**: Firestoreの読み取りコストを大幅に削減  
✅ **ユーザー体験向上**: アプリ起動速度の改善  
✅ **シンプルな実装**: MultiProviderが不要になり、コードが簡潔に

## テスト結果
- ✅ 全104件のテストが成功
- ✅ 静的解析で新たなエラーなし

## 関連Issue
Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)